### PR TITLE
README: Correct Compile->CLI instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ git clone https://github.com/Ryzee119/ogx360_t4.git --recursive
 python -m pip install --upgrade pip
 pip install platformio
 cd ogx360_t4
-platformio run -e teensy41
+# Build XMU (memory unit) emulator
+platformio run -e XMU
+# Build controller translator
+platformio run -e DUKE
 ```
 ### Visual Studio Code
 * Download and install [Visual Studio Code](https://code.visualstudio.com/).


### PR DESCRIPTION
On commit 067db9a the single build env `teensy41` was replaced with two seperate build environments, `XMU` and `DUKE`.

This PR reflects the change in the **Compile->CLI** section of the README file.